### PR TITLE
Change the Flagship edition info

### DIFF
--- a/src/pages/download.astro
+++ b/src/pages/download.astro
@@ -15,7 +15,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <div class="">
           <div class="grid grid-flow-row-dense grid-cols-1 gap-10 pt-12 md:grid-cols-2 md:flex-row">
             <DownloadSectionNew editionName="Flagship" screenshot="../ultramarine.png"
-              description="The flagship edition with the latest and greatest software and our best polish. Powered by Solus' Budgie Desktop. (Recommended)"
+              description="The flagship edition with the latest and greatest software and our best polish. Powered by Budgie Desktop. (Recommended)"
               downloadLink="https://repos.fyralabs.com/isos/ultramarine/37/ultramarine-flagship-x86_64-20230106.iso" />
 
             <DownloadSectionNew editionName="GNOME" screenshot="../GNOME.png"


### PR DESCRIPTION
Change ``Powered by Solus's Budgie Desktop`` to ``Powered by Budgie Desktop`` since the Budgie desktop became independent from the Solus Project and it's now worked on by the Budgies of Budgie group