### PR TITLE
fix: change on Footer.vue file to automatically include the current year

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -5,7 +5,7 @@
   >
     <div class="flex flex-col">
       <span class="font-semibold tracking-wide">
-        Copyright © 2021 - 2023 Fyra Labs
+        Copyright © 2021 - {{ new Date().getFullYear() }} Fyra Labs
       </span>
       <a
         href="/licenses"


### PR DESCRIPTION
Quick fix to eliminate the hassle of manually changing the year in the page footer.