### PR TITLE
chore: update copyright year

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -5,7 +5,7 @@
   >
     <div class="flex flex-col">
       <span class="font-semibold tracking-wide">
-        Copyright © 2021 - 2023 Fyra Labs
+        Copyright © 2021 - 2024 Fyra Labs
       </span>
       <a
         href="/licenses"


### PR DESCRIPTION
self-explanatory, updates the copyright year in the footer since apparently no one else has done it yet